### PR TITLE
Test cases that confirms that Issue #240 has been fixed.

### DIFF
--- a/node/tests/controllers/Login-Controller.test.coffee
+++ b/node/tests/controllers/Login-Controller.test.coffee
@@ -58,6 +58,9 @@ describe "controllers | test-Login-Controller |", ->
     invoke_LoginUser 'tm','tm', mainPage_user, ->
       invoke_LoginUser 'user','a', mainPage_user, done
 
+  it "LoginUser(undefined Login_Status using existential operator)", (done)->
+    invoke_LoginUser undefined ,undefined , loginPage, done
+
   it 'logoutUser', (done)->
     invoke_Method "logoutUser", {} ,mainPage_no_user,done
 


### PR DESCRIPTION
https://github.com/TeamMentor/TM_4_0_Design/issues/240

By providing undefined parameters as a part of the payload, the response from the service does not contain a Login_Status. The usage of the existential operator fixes it.