### PR TITLE
Fixing Issue 627 (Minor fix for navigation menu)

### DIFF
--- a/src/controllers/Search-Controller.coffee
+++ b/src/controllers/Search-Controller.coffee
@@ -82,13 +82,13 @@ class SearchController
                   @res.send(@renderPage())
                 else
                   logger?.info {Error:'There are no results that match the search.',queryId: queryId, filters:filters}
-                  @res.send @jade_Service.renderJadeFile(@.jade_Error_Page)
+                  @res.send @jade_Service.renderJadeFile(@.jade_Error_Page,{loggedIn:@.req.session?.username != undefined})
             else
               if (@searchData.results?)
                 @res.send(@renderPage())
               else
                 logger?.info {Error:'There are no results that match the search.',queryId: queryId, filters:filters}
-                @res.send @jade_Service.renderJadeFile(@.jade_Error_Page)
+                @res.send @jade_Service.renderJadeFile(@.jade_Error_Page,{loggedIn:@.req.session?.username != undefined})
 
     search_Via_Url: =>
       @.req.query.text = @.req.params.text


### PR DESCRIPTION
This fix is required because the navigation menu was broken. When an error was displayed, the Login and Sign Up liks were enabled, even when the user was already logged in.

Here is the text that verifies this fix.

@DinisCruz  can you please review this fix and the test below?

```jade
it.only  'Issue 606 - Changing query number in URL clears UI', (done) ->
    jade.login_As_User ()->
      page.open '/show/query-6204f2d47eb7/query-f3d932e485feC', (html,$)->
        $('#404-message').html().assert_Is_Not_Null();
        $('#404-message h1').html().assert_Is("An error occurred")
        $('#404-message p').html().assert_Contains("It&apos;s a HTTP 404 error - check the URL and refresh the browser.")

        #Verifying navigation bar
        $('#links').text().assert_Not_Contains("Login");
        $('#links').text().assert_Not_Contains('SignUp');
        $('#nav-sign-up').assert_Is_Undefined()
        $('#nav-login').assert_Is_Undefined()
        $('#nav-user-logout span').html().assert_Is('Logout')
        $('#message').text().assert_Is('Found an issue? Send us an email.')
        done()
```

And this is the UI

![screen shot 2015-04-07 at 10 54 45 pm](https://cloud.githubusercontent.com/assets/1732035/7039049/d2a1e780-dd78-11e4-9585-7390ee336eff.png)
