### PR TITLE
Fixing broken test

### DIFF
--- a/test/routes/routes.test.coffee
+++ b/test/routes/routes.test.coffee
@@ -117,7 +117,11 @@ describe '| routes | routes.test |', ()->
       it testName, (done) ->
 
         checkResponse = (error,response) ->
-          assert_Is_Null(error)
+          if(response.statusCode is 200)
+            assert_Is_Null(error)
+          else
+            assert_Is_Not_Null(error)
+
           response.text.assert_Is_String()
           done()
         if (postRequest)


### PR DESCRIPTION
Fixing broken test. As a reference look at the supertest changes https://github.com/visionmedia/supertest/blob/master/Readme.md

>"One thing to note with the above statement is that superagent now sends any HTTP error (anything other than a 2XX response code) to the callback as the first arguement. Example:"